### PR TITLE
The commit is caused by bug:

### DIFF
--- a/rpm2cvescan.py
+++ b/rpm2cvescan.py
@@ -183,7 +183,7 @@ class my_rpm:
         if 'el' in self.version_string:
            self.rhversion = self.version_string.split('el')[1].split('.')[0]
         else:
-           self.rhversion = 0
+           self.rhversion = '0'
 
     def __eq__(self, other):
         """Override the default Equals behavior"""


### PR DESCRIPTION
"Traceback (most recent call last):
File "rpm2cvescan.py", line 716, in
patchstatus = check_patchlist(patchlist[rhelversion], rpmlist)
File "rpm2cvescan.py", line 468, in check_patchlist
if patch_rpm.rhversion[0] == system_rpm.rhversion[0]:
TypeError: 'int' object has no attribute 'getitem'
"
I think, that exception is caused by:

"if 'el' in self.version_string:
self.rhversion = self.version_string.split('el')[1].split('.')[0]
else:
self.rhversion = 0
"

If self.rhversion == 0 there is a problem because you cant't do rhversion[0] because it is int.
I think the the code should be:

"if 'el' in self.version_string:
self.rhversion = self.version_string.split('el')[1].split('.')[0]
else:
self.rhversion = '0'
"

After that, rhversion is always "string" and not "int" in some cases